### PR TITLE
fort5_ds.shader: use correct skybox filenames

### DIFF
--- a/scripts/fort5_ds.shader
+++ b/scripts/fort5_ds.shader
@@ -812,7 +812,7 @@ textures/fort5_ds/skybox
 	surfaceparm slick
 	surfaceparm nolightmap
 	q3map_sun 1 1 1 60 180 50
-	skyparms env/fort5_ds/neptune - -
+	skyparms env/fort5_ds/skybox - -
 	{
 		map env/fort5_ds/clouds.jpg
 		blendFunc add


### PR DESCRIPTION
The skybox image files in `env/fort5_ds` are named `skybox`, not `neptune`. Fix this in the skybox shader.